### PR TITLE
Don't consider PvP .entities files online-safe

### DIFF
--- a/include/ProgramOptions.hpp
+++ b/include/ProgramOptions.hpp
@@ -22,7 +22,7 @@
 #include <string>
 #include <sstream>
 
-#define VERSION 22
+#define VERSION 23
 
 #ifdef _WIN32
 #define SEPARATOR static_cast<char>(fs::path::preferred_separator)

--- a/src/OnlineSafety.cpp
+++ b/src/OnlineSafety.cpp
@@ -129,7 +129,8 @@ static const std::vector<std::string> OnlineSafeModNameKeywords = {
     "/renderparmmeta/", "/renderprogflag/", "/ribbon2/", "/rumble/", "/soundevent/", "/soundpack/", "/soundrtpc/", "/soundstate/", "/soundswitch/",
     "/speaker/", "/staticimage/", "/swfresources/", "/uianchor/", "/uicolor/", "/weaponreticle/", "/weaponreticleswfinfo/", "/entitydef/light/", "/entitydef/fx",
     "/impacteffect/", "/uiweapon/", "/globalinitialwarehouse/", "/globalshell/", "/warehouseitem/", "/warehouseofflinecontainer/", "/tooltip/", "/livetile/",
-    "/tutorialevent/", "/maps/game/dlc/", "/maps/game/dlc2/", "/maps/game/hub/", "/maps/game/shell/", "/maps/game/sp/", "/maps/game/tutorials/", "/decls/campaign/"
+    "/tutorialevent/", "maps/game/dlc/", "maps/game/dlc2/", "maps/game/horde/", "maps/game/hub/", "maps/game/shell/", "maps/game/sp/", "maps/game/tutorials/",
+    "/decls/campaign/"
 };
 
 // Online unsafe resource names
@@ -217,8 +218,8 @@ bool IsModSafeForOnline(const std::map<size_t, std::vector<ResourceModFile>>& re
                 return false;
             }
 
-            // Allow modification of anything outside of "generated/decls/"
-            if (!StartsWith(ToLower(modFile.Name), "generated/decls/")) {
+            // Allow modification of anything outside of "generated/decls/", except .entities files
+            if (!StartsWith(ToLower(modFile.Name), "generated/decls/") && !EndsWith(ToLower(modFile.Name), ".entities")) {
                 continue;
             }
 


### PR DESCRIPTION
Untested. Fixes a false positive with some mods being erroneously considered online-safe, by making *.entities* files go through the same path checks as *generated/decls/\*.decl* files.

The "*/maps/\**" whitelists were changed to "*maps/\**" (without a slash at the start) so that they'll also match (online-safe) .entities files, and "*maps/game/horde/*" was added so that Horde *.entities* files are still considered online-safe.

See also: https://github.com/dcealopez/EternalModLoader/pull/20